### PR TITLE
Support OpenGL 3.0 and 3.1 in the trigl3 test

### DIFF
--- a/test/trigl3.ml
+++ b/test/trigl3.ml
@@ -37,12 +37,13 @@ let get_string len f =
 (* Shaders *)  
 
 let glsl_version gl_version = match gl_version with
-| 3,2 -> "150" | 3,3 -> "330" 
-| 4,0 -> "400" | 4,1 -> "410" | 4,2 -> "420" | 4,3 -> "430" | 4,4 -> "440"
+| 3,0 -> "130" | 3,1 -> "140"
+| 3,2 -> "150 core" | 3,3 -> "330 core"
+| 4,0 -> "400 core" | 4,1 -> "410 core" | 4,2 -> "420 core" | 4,3 -> "430 core" | 4,4 -> "440 core"
 | _ -> assert false
 
 let vertex_shader v = str "
-  #version %s core
+  #version %s
   in vec3 vertex;
   in vec3 color;
   out vec4 v_color;
@@ -53,7 +54,7 @@ let vertex_shader v = str "
   }" v
 
 let fragment_shader v = str "
-  #version %s core
+  #version %s
   in vec4 v_color;
   out vec4 color;
   void main() { color = v_color; }" v


### PR DESCRIPTION
[sorry, something went wrong with previous pull request]

The open-source Mesa radeon driver supports only OpenGL 3.1 on my GPU, with this change I can run the trigl3 test successfully.

For OpenGL <3.2 we should probably not request a core profile either (although it works on Mesa to do so).

OpenGL vendor string: X.Org
OpenGL renderer string: Gallium 0.4 on AMD RV730
OpenGL core profile version string: 3.1 (Core Profile) Mesa 10.0.1
OpenGL core profile shading language version string: 1.40
OpenGL core profile context flags: (none)
OpenGL core profile extensions:
OpenGL version string: 3.0 Mesa 10.0.1
OpenGL shading language version string: 1.30
OpenGL context flags: (none)
OpenGL extensions:
