### PR TITLE
specify precision for fragment shader

### DIFF
--- a/test/trigles2.ml
+++ b/test/trigles2.ml
@@ -47,6 +47,7 @@ let vertex_shader = "
 
 let fragment_shader = "
   #version 100
+  precision highp float;
   varying vec4 v_color;
   void main() { gl_FragColor = v_color; }"
 

--- a/test/trigles3.ml
+++ b/test/trigles3.ml
@@ -47,6 +47,7 @@ let vertex_shader = "
 
 let fragment_shader = "
   #version 330 es
+  precision highp float;
   in vec4 v_color;
   out vec4 color;
   void main() { color = v_color; }"


### PR DESCRIPTION
Fixes "0:3(14): error: no precision specified this scope for type `vec4'"

The default for the vertex shader is 'precision highp float',
but there is no such default for the fragment shader, see
4.5.3 "Default Precision Qualifiers" in GLSL_ES_Specification_1.0.17.pdf

trigles2 now works with  "OpenGL ES 3.0 Mesa 10.0.2", IF I have libgles2-mesa-dev installed at build time.
