### PR TITLE
ctypes: depend explicitly on ctypes.foreign

### DIFF
--- a/_tags
+++ b/_tags
@@ -6,7 +6,7 @@ true: thread, bin_annot, safe_string
 <support/**> : package(xmlm)
 
 <src> : include
-<src/tgl{3,4,es2,es3}.{ml,mli}> : package(ctypes)
+<src/tgl{3,4,es2,es3}.{ml,mli}> : package(ctypes), package(ctypes.foreign)
 <src/tgl{3,4,es2,es3}.{cma,cmxa,cmxs}> : custom, thread, \
   package(ctypes), package(ctypes.foreign)
 <src/tgl{3,4,es2,es3}_top.*> : package(compiler-libs.toplevel)


### PR DESCRIPTION
In ctypes < 0.21.0, the ctypes and ctypes.foreign libraries were
installed in the same directory, so depending on one would make the
other one visible.
ctypes 0.21.0 installs them in different directories so this makes it an
error.
tgls actually uses ctypes.foreign so this adds the dependency.
