### PR TITLE
Make tgls work on Windows + MingW64

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
 
+* Fix Tgls on Windows + MingW64
+  * Try to load [opengl32.dll] at startup on Windows.
+  * Bring 64-bit Windows support by fixing selection of FFI ABI.
+  * Unlock the full OpenGL API on Windows by implementing indirect
+    procedure lookup with [wglGetProcAddress].
 * Fix build system. Explicitely depend on `ctypes-foreign`. 
   Thanks to Etienne Millon for the patch (#29).
 * Fix `Gl.debug_message_callback` raising `Ffi_stubs.CallToExpiredClosure`. 

--- a/src/tgl4.ml
+++ b/src/tgl4.ml
@@ -10,9 +10,51 @@
 open Ctypes
 open Foreign
 
-let abi = Libffi_abi.(if Sys.win32 then stdcall else default_abi)
-let foreign ?from ?stub ?check_errno ?release_runtime_lock f fn =
-foreign ~abi ?from ?stub ?check_errno ?release_runtime_lock f fn
+let from =
+  if Sys.win32 then
+    try
+      Some (Dl.(dlopen ~filename:"opengl32.dll" ~flags:[ RTLD_NOW ]))
+    with _ ->
+      (* In case some setups don't have the standard [opengl32.dll],
+         don't prevent running by failing at toplevel. *)
+      None
+  else None
+
+let abi =
+  if Sys.win32 && Sys.word_size = 32 then
+    (* On X86 (32-bit) under Windows, [opengl32.dll] uses the [__stdcall] FFI ABI.
+       This is not the default for [libffi], so it may require passing a [~abi] paraameter.
+       Just in case, we try to look for one procedure, and revert to default if it fails.
+       In all other situations, we use the default FFI ABI. *)
+    try
+      ignore (foreign ?from ~abi:Libffi_abi.stdcall "glClear" (int @-> returning void)) ;
+      Libffi_abi.stdcall
+    with _ -> Libffi_abi.default_abi
+  else Libffi_abi.default_abi
+
+let foreign ?stub ?check_errno ?release_runtime_lock f fn =
+  if Sys.win32 then
+    (* In [opengl32.dll], non OpenGL 1.1 procedures must be looked up up via [wglGetProcAddress].
+       To simplify things, we don't hardcode the list but do a two-step auto-detection.
+       Some functions can only be resolved after OpenGL is initialized, so we delay the
+       lookup until the first call and cache the lookup result.*)
+    let cache = ref None in
+    fun x -> 
+      match !cache with
+      | Some f -> f x
+      | None ->
+        try
+          let fp = foreign ~abi ?from ~stub:false ?check_errno ?release_runtime_lock f fn in
+          cache := Some fp;
+          fp x
+        with Dl.DL_error _ ->
+          let ftyp = funptr_opt fn in
+          match foreign ~abi ?from "wglGetProcAddress" (string @-> returning ftyp) f with
+          | None -> failwith ("Could not resolve OpenGL procedure " ^ f)
+          | Some fpp ->
+            cache := Some fpp ;
+            fpp x
+  else foreign ~abi ?from ?stub ?check_errno ?release_runtime_lock f fn 
 
 (* OpenGL 4.x bindings *)
 
@@ -194,7 +236,7 @@ module Gl = struct
   
   (* Functions *)
 
-  let stub = true
+  let stub = true (* If changed, will need updating Windows specific [foreign]. *)
 
   let active_shader_program =
     foreign ~stub "glActiveShaderProgram"

--- a/src/tgles2.ml
+++ b/src/tgles2.ml
@@ -10,9 +10,51 @@
 open Ctypes
 open Foreign
 
-let abi = Libffi_abi.(if Sys.win32 then stdcall else default_abi)
-let foreign ?from ?stub ?check_errno ?release_runtime_lock f fn =
-foreign ~abi ?from ?stub ?check_errno ?release_runtime_lock f fn
+let from =
+  if Sys.win32 then
+    try
+      Some (Dl.(dlopen ~filename:"opengl32.dll" ~flags:[ RTLD_NOW ]))
+    with _ ->
+      (* In case some setups don't have the standard [opengl32.dll],
+         don't prevent running by failing at toplevel. *)
+      None
+  else None
+
+let abi =
+  if Sys.win32 && Sys.word_size = 32 then
+    (* On X86 (32-bit) under Windows, [opengl32.dll] uses the [__stdcall] FFI ABI.
+       This is not the default for [libffi], so it may require passing a [~abi] paraameter.
+       Just in case, we try to look for one procedure, and revert to default if it fails.
+       In all other situations, we use the default FFI ABI. *)
+    try
+      ignore (foreign ?from ~abi:Libffi_abi.stdcall "glClear" (int @-> returning void)) ;
+      Libffi_abi.stdcall
+    with _ -> Libffi_abi.default_abi
+  else Libffi_abi.default_abi
+
+let foreign ?stub ?check_errno ?release_runtime_lock f fn =
+  if Sys.win32 then
+    (* In [opengl32.dll], non OpenGL 1.1 procedures must be looked up up via [wglGetProcAddress].
+       To simplify things, we don't hardcode the list but do a two-step auto-detection.
+       Some functions can only be resolved after OpenGL is initialized, so we delay the
+       lookup until the first call and cache the lookup result.*)
+    let cache = ref None in
+    fun x -> 
+      match !cache with
+      | Some f -> f x
+      | None ->
+        try
+          let fp = foreign ~abi ?from ~stub:false ?check_errno ?release_runtime_lock f fn in
+          cache := Some fp;
+          fp x
+        with Dl.DL_error _ ->
+          let ftyp = funptr_opt fn in
+          match foreign ~abi ?from "wglGetProcAddress" (string @-> returning ftyp) f with
+          | None -> failwith ("Could not resolve OpenGL procedure " ^ f)
+          | Some fpp ->
+            cache := Some fpp ;
+            fpp x
+  else foreign ~abi ?from ?stub ?check_errno ?release_runtime_lock f fn 
 
 (* OpenGL ES 2 bindings *)
 
@@ -130,7 +172,7 @@ module Gl = struct
   
   (* Functions *)
 
-  let stub = true
+  let stub = true (* If changed, will need updating Windows specific [foreign]. *)
 
   let active_texture =
     foreign ~stub "glActiveTexture" (int_as_uint @-> returning void)

--- a/src/tgles3.ml
+++ b/src/tgles3.ml
@@ -10,9 +10,51 @@
 open Ctypes
 open Foreign
 
-let abi = Libffi_abi.(if Sys.win32 then stdcall else default_abi)
-let foreign ?from ?stub ?check_errno ?release_runtime_lock f fn =
-foreign ~abi ?from ?stub ?check_errno ?release_runtime_lock f fn
+let from =
+  if Sys.win32 then
+    try
+      Some (Dl.(dlopen ~filename:"opengl32.dll" ~flags:[ RTLD_NOW ]))
+    with _ ->
+      (* In case some setups don't have the standard [opengl32.dll],
+         don't prevent running by failing at toplevel. *)
+      None
+  else None
+
+let abi =
+  if Sys.win32 && Sys.word_size = 32 then
+    (* On X86 (32-bit) under Windows, [opengl32.dll] uses the [__stdcall] FFI ABI.
+       This is not the default for [libffi], so it may require passing a [~abi] paraameter.
+       Just in case, we try to look for one procedure, and revert to default if it fails.
+       In all other situations, we use the default FFI ABI. *)
+    try
+      ignore (foreign ?from ~abi:Libffi_abi.stdcall "glClear" (int @-> returning void)) ;
+      Libffi_abi.stdcall
+    with _ -> Libffi_abi.default_abi
+  else Libffi_abi.default_abi
+
+let foreign ?stub ?check_errno ?release_runtime_lock f fn =
+  if Sys.win32 then
+    (* In [opengl32.dll], non OpenGL 1.1 procedures must be looked up up via [wglGetProcAddress].
+       To simplify things, we don't hardcode the list but do a two-step auto-detection.
+       Some functions can only be resolved after OpenGL is initialized, so we delay the
+       lookup until the first call and cache the lookup result.*)
+    let cache = ref None in
+    fun x -> 
+      match !cache with
+      | Some f -> f x
+      | None ->
+        try
+          let fp = foreign ~abi ?from ~stub:false ?check_errno ?release_runtime_lock f fn in
+          cache := Some fp;
+          fp x
+        with Dl.DL_error _ ->
+          let ftyp = funptr_opt fn in
+          match foreign ~abi ?from "wglGetProcAddress" (string @-> returning ftyp) f with
+          | None -> failwith ("Could not resolve OpenGL procedure " ^ f)
+          | Some fpp ->
+            cache := Some fpp ;
+            fpp x
+  else foreign ~abi ?from ?stub ?check_errno ?release_runtime_lock f fn 
 
 (* OpenGL ES 3.x bindings *)
 
@@ -159,7 +201,7 @@ module Gl = struct
   
   (* Functions *)
 
-  let stub = true
+  let stub = true (* If changed, will need updating Windows specific [foreign]. *)
 
   let active_shader_program =
     foreign ~stub "glActiveShaderProgram"

--- a/support/gen.ml
+++ b/support/gen.ml
@@ -226,8 +226,17 @@ let pp_ml_module ~log ppf api =
     "@[<v>\
      open Ctypes@,\
      open Foreign@,@,\
+     let from =@,\
+     \  if Sys.win32 then@,\
+     \    try@,\
+     \      Some (Dl.(dlopen ~filename:\"opengl32.dll\" ~flags:[ RTLD_NOW ]))@,\
+     \    with _ ->@,\
+     \      (* In case some setups don't have the standard [opengl32.dll],@,\
+     \         don't prevent running by failing at toplevel. *)@,\
+     \      None@,\
+     \  else None@,@,\
      let abi = Libffi_abi.(if Sys.win32 then stdcall else default_abi)@,\
-     let foreign ?from ?stub ?check_errno ?release_runtime_lock f fn =@,\
+     let foreign ?stub ?check_errno ?release_runtime_lock f fn =@,\
        foreign ~abi ?from ?stub ?check_errno ?release_runtime_lock f fn@,@,\
      (* %s bindings *)@,@,\
      module %s = struct@,@,\


### PR DESCRIPTION
This PR implements three fixes to make tgls work on Windows, in three patches.

First, it patches the choice of FFI API used by Ctypes Foreign.
The current code chooses the FFI API using an `if Sys.win32` test.
This does not work with a MingW64 based distribution of OCaml, which is what you get by default with OPAM 2.3.
I am not sure exactly if this is a wrong test to test for an MSVC install, or if it misses the 32-bit test.
So I suggest a dynamic test: the patch tries to load a simple C primitive (`abs`) with the `stdcall` convention, and selects the default convention if it fails.
It works on my systems (does not break Debian, makes Windows 11+MingW64 work). I am not sure if that is 100% safe everywhere. In particular, I have not managed to run tgls with MSVC or on a 32-bit system yet.

Second, it loads the `opengl32.dll` at startup if `Sys.win32`.
This is the way to go on Windows, so it removes the need for all users to do the `dlopen` themselves.
The patch does not fail if it does not manage to load the `dll`, so if there are non standard setups that require non standard initialization, it should still be safe.

Finally, on Windows, OpenGL is provided by `opengl32.dll` that only provides symbols for an old version of OpenGL (internet says 1.1, I am not sure).
To use modern OpenGL calls, the lookup needs to go through a specific lookup function.
The 3rd patch implements that logic.